### PR TITLE
Create ingresses for faucets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 src/webpage/_site
+node_modules

--- a/TezosChain.ts
+++ b/TezosChain.ts
@@ -3,7 +3,7 @@ import * as k8s from "@pulumi/kubernetes";
 import * as awsx from "@pulumi/awsx";
 import * as aws from "@pulumi/aws";
 import * as cronParser from "cron-parser";
-import { createAliasRecord } from "./route53";
+import { createCertValidation } from "./route53";
 import { publicReadPolicyForBucket } from "./s3";
 import { TezosImageResolver } from "./TezosImageResolver";
 
@@ -355,39 +355,8 @@ export class TezosChain extends pulumi.ComponentResource {
         return obj;
       },
       {}
-    );
-    params.helmValues["tezos_k8s_images"] = pulumiTaggedImages;
-
-    if (params.getNumberOfFaucetAccounts() > 0) {
-        // deploy a faucet website
-        const chainSpecificSeed = `${params.getFaucetSeed()}-${params.getChainName()}`;
-        const faucetAccountGenImg = this.repo.buildAndPushImage("tezos-faucet/account-gen");
-        const faucetAppImg = this.repo.buildAndPushImage("tezos-faucet/app");
-
-        var faucet = new k8s.helm.v2.Chart(`${name}-faucet`, {
-          namespace: ns.metadata.name,
-          path: `tezos-faucet/charts/faucet`,
-          values: { "recaptcha_keys":
-              {
-                  "siteKey": params.getFaucetRecaptchaSiteKey(),
-                  "secretKey": params.getFaucetRecaptchaSecretKey(),
-              },
-              "number_of_accounts": params.getNumberOfFaucetAccounts(),
-              "seed": chainSpecificSeed,
-              "images": {
-                  "account_gen": faucetAccountGenImg,
-                  "faucet": faucetAppImg,
-              },
-          },
-        }, { providers: { "kubernetes": this.provider } });
-
-        // add the faucet seed to the activation parameters so the accounts given
-        // by the faucet website work on chain
-        params.helmValues["activation"]["deterministic_faucet"] = {
-            "seed": chainSpecificSeed,
-            "number_of_accounts": params.getNumberOfFaucetAccounts(),
-        }
-    }
+    )
+    params.helmValues["tezos_k8s_images"] = pulumiTaggedImages
 
     // deploy from repository
     //this.chain = new k8s.helm.v2.Chart(this.name, {
@@ -440,7 +409,112 @@ export class TezosChain extends pulumi.ComponentResource {
       { provider: this.provider }
     )
 
+    if (params.getNumberOfFaucetAccounts() > 0) {
+      // deploy a faucet website
+      const chainSpecificSeed = `${params.getFaucetSeed()}-${params.getChainName()}`
+      const faucetAccountGenImg = this.repo.buildAndPushImage(
+        "tezos-faucet/account-gen"
+      )
+      const faucetAppImg = this.repo.buildAndPushImage("tezos-faucet/app")
+
+      new k8s.helm.v2.Chart(
+        `${name}-faucet`,
+        {
+          namespace: ns.metadata.name,
+          path: `tezos-faucet/charts/faucet`,
+          values: {
+            recaptcha_keys: {
+              siteKey: params.getFaucetRecaptchaSiteKey(),
+              secretKey: params.getFaucetRecaptchaSecretKey(),
+            },
+            number_of_accounts: params.getNumberOfFaucetAccounts(),
+            seed: chainSpecificSeed,
+            images: {
+              account_gen: faucetAccountGenImg,
+              faucet: faucetAppImg,
+            },
+          },
+        },
+        { providers: { kubernetes: this.provider } }
+      )
+
+      // add the faucet seed to the activation parameters so the accounts given
+      // by the faucet website work on chain
+      params.helmValues["activation"]["deterministic_faucet"] = {
+        seed: chainSpecificSeed,
+        number_of_accounts: params.getNumberOfFaucetAccounts(),
+      }
+
+      const faucetDomain = `faucet.${teztnetsDomain}`
+      const faucetCert = new aws.acm.Certificate(
+        `${faucetDomain}-cert`,
+        {
+          validationMethod: "DNS",
+          domainName: faucetDomain,
+        },
+        { protect: true, parent: this }
+      )
+      const { certValidation } = createCertValidation(
+        {
+          cert: faucetCert,
+          targetDomain: faucetDomain,
+          hostedZone: teztnetsHostedZone,
+        },
+        { parent: this }
+      )
+
+      const ingressName = `${faucetDomain}-ingress`
+      new k8s.networking.v1beta1.Ingress(
+        ingressName,
+        {
+          metadata: {
+            namespace: ns.metadata.name,
+            name: ingressName,
+            annotations: {
+              "kubernetes.io/ingress.class": "alb",
+              "alb.ingress.kubernetes.io/scheme": "internet-facing",
+              "alb.ingress.kubernetes.io/healthcheck-path": "/",
+              "alb.ingress.kubernetes.io/healthcheck-port": "8081",
+              "alb.ingress.kubernetes.io/listen-ports": '[{"HTTP": 80}, {"HTTPS":443}]',
+              "ingress.kubernetes.io/force-ssl-redirect": "true",
+              "alb.ingress.kubernetes.io/actions.ssl-redirect":
+                '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}',
+            },
+            labels: { app: "faucet" },
+          },
+          spec: {
+            rules: [
+              {
+                host: faucetDomain,
+                http: {
+                  paths: [
+                    {
+                      path: "/*",
+                      backend: {
+                        serviceName: "ssl-redirect",
+                        servicePort: "use-annotation",
+                      },
+                    },
+                    {
+                      path: "/*",
+                      backend: {
+                        serviceName: "faucet",
+                        servicePort: "http",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        { provider, parent: this, dependsOn: certValidation }
+      )
+    }
+
+
   }
+
 
   getChainName(): string {
     return this.params.getChainName();

--- a/externalDns.ts
+++ b/externalDns.ts
@@ -1,0 +1,60 @@
+// copied from tqinfra
+import * as aws from "@pulumi/aws"
+import * as eks from "@pulumi/eks"
+import * as k8s from "@pulumi/kubernetes"
+
+const deployExternalDns = (cluster: eks.Cluster) => {
+  // Create a new IAM Policy for external-dns to manage R53 record sets.
+  const externalDnsPolicy = new aws.iam.Policy("external-dns-iam-policy", {
+    description: "Allows k8s external-dns to manage R53 Hosted Zone records.",
+    policy: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: ["route53:ChangeResourceRecordSets"],
+          Resource: ["arn:aws:route53:::hostedzone/*"],
+        },
+        {
+          Effect: "Allow",
+          Action: ["route53:ListHostedZones", "route53:ListResourceRecordSets"],
+          Resource: ["*"],
+        },
+      ],
+    }),
+  })
+
+  new aws.iam.RolePolicyAttachment("external-dns-iam-role", {
+    policyArn: externalDnsPolicy.arn,
+    role: cluster.instanceRoles.apply((roles) => roles[0].name),
+  })
+
+  new k8s.helm.v2.Chart(
+    "external-dns",
+    {
+      chart: "external-dns",
+      version: "5.1.4",
+      namespace: "default",
+      fetchOpts: {
+        repo: "https://charts.bitnami.com/bitnami",
+      },
+      // https://artifacthub.io/packages/helm/bitnami/external-dns#etcd-parameters
+      values: {
+        replicas: 2,
+        // This tells extnernal-dns to only track records in the hosted zone
+        // that were created for this cluster. Otherwise it will sync all records
+        // in the hosted zone.
+        txtOwnerId: cluster.eksCluster.name,
+        // This will delete route53 records after an ingress or its hosts are
+        // deleted.
+        policy: "sync",
+        aws: {
+          zoneType: "public",
+        },
+      },
+    },
+    { providers: { kubernetes: cluster.provider } }
+  )
+}
+
+export default deployExternalDns

--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,7 @@ import * as awsx from "@pulumi/awsx";
 import * as aws from "@pulumi/aws";
 
 import deployAwsAlbController from "./awsAlbController"
+import deployExternalDns from "./externalDns"
 import { TezosChain, TezosChainParametersBuilder } from "./TezosChain";
 
 let stack = pulumi.getStack();
@@ -90,6 +91,7 @@ export const clusterNodeInstanceRoleName = cluster.instanceRoles.apply(
 );
 
 deployAwsAlbController(cluster)
+deployExternalDns(cluster)
 
 const periodicCategory = "Periodic Teztnets";
 const longCategory = "Long-Running Teztnets";
@@ -188,7 +190,7 @@ function getNetworks(chains: TezosChain[]): object {
     chains.forEach(function (chain) {
         const bootstrapPeers: string[] = Object.assign([], chain.params.getPeers()); // clone
         bootstrapPeers.splice(0, 0, `${chain.params.getDnsName()}.tznode.net`);
-    
+
         // genesis_pubkey is the public key associated with the $TEZOS_BAKING_KEY private key in github secrets
         // TODO: generate it dynamically based on privkey
         const genesisPubkey = "edpkuix6Lv8vnrz6uDe1w8uaXY7YktitAxn6EHdy2jdzq5n5hZo94n";
@@ -204,7 +206,7 @@ function getNetworks(chains: TezosChain[]): object {
         if ("activation_account_name" in network) {
             delete network["activation_account_name"];
         };
-        
+
         networks[chain.params.getName()] = network;
     })
 


### PR DESCRIPTION
closes #39 

- deploys external-dns
- external-dns creates the alias records for the p2p LB's and the faucet LB's
- faucet LB's have ssl enabled