### PR TITLE
add rpc ingress

### DIFF
--- a/TezosChain.ts
+++ b/TezosChain.ts
@@ -496,7 +496,7 @@ export class TezosChain extends pulumi.ComponentResource {
       { parent: this }
     )
 
-    const rpcIngName = `${name}-rpc-ingress`
+    const rpcIngName = `${rpcDomain}-ingress`
     const rpc_ingress = new k8s.networking.v1beta1.Ingress(
       rpcIngName,
       {

--- a/TezosChain.ts
+++ b/TezosChain.ts
@@ -487,7 +487,7 @@ export class TezosChain extends pulumi.ComponentResource {
       },
       { parent: this }
     )
-    const rpcCertValidation = createCertValidation(
+    const { certValidation } = createCertValidation(
       {
         cert: rpcCert,
         targetDomain: rpcDomain,
@@ -545,7 +545,7 @@ export class TezosChain extends pulumi.ComponentResource {
           ],
         },
       },
-      { provider, parent: this, dependsOn: rpcCertValidation.certValidation }
+      { provider, parent: this, dependsOn: certValidation }
     )
     if (params.getChartRepo() == '') {
       // assume tezos-k8s submodule present; build custom images, and deploy custom chart from path

--- a/TezosChain.ts
+++ b/TezosChain.ts
@@ -520,16 +520,9 @@ export class TezosChain extends pulumi.ComponentResource {
           labels: { app: "tezos-node" },
         },
         spec: {
-          // https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/cert_discovery/#discover-via-ingress-tls
-          tls: [
-            {
-              hosts: rpcCert.domainValidationOptions.apply((dvos) =>
-                dvos.map((dvo) => dvo.domainName)
-              ),
-            },
-          ],
           rules: [
             {
+              host: rpcDomain,
               http: {
                 paths: [
                   {
@@ -552,7 +545,7 @@ export class TezosChain extends pulumi.ComponentResource {
           ],
         },
       },
-        { provider, parent: this, dependsOn: rpcCertValidation.certValidation }
+      { provider, parent: this, dependsOn: rpcCertValidation.certValidation }
     )
     if (params.getChartRepo() == '') {
       // assume tezos-k8s submodule present; build custom images, and deploy custom chart from path

--- a/TezosChain.ts
+++ b/TezosChain.ts
@@ -501,7 +501,7 @@ export class TezosChain extends pulumi.ComponentResource {
       rpcIngName,
       {
         metadata: {
-          namespace: name,
+          namespace: ns.metadata.name,
           name: rpcIngName,
           annotations: {
             "kubernetes.io/ingress.class": "alb",

--- a/TezosChain.ts
+++ b/TezosChain.ts
@@ -496,12 +496,12 @@ export class TezosChain extends pulumi.ComponentResource {
       { parent: this }
     )
 
-    const rpcIngName = `${ns.metadata.name}-rpc-ingress`
+    const rpcIngName = `${name}-rpc-ingress`
     const rpc_ingress = new k8s.networking.v1beta1.Ingress(
       rpcIngName,
       {
         metadata: {
-          namespace: ns.metadata.name,
+          namespace: name,
           name: rpcIngName,
           annotations: {
             "kubernetes.io/ingress.class": "alb",


### PR DESCRIPTION
Deploy a RPC ingress for every testnet. People won't have to run a node and sync the chain to interact with it, they just need a client and a faucet account.