### PR TITLE
step 3: activate

### DIFF
--- a/idiazabalnet/values.yaml
+++ b/idiazabalnet/values.yaml
@@ -256,6 +256,13 @@ accounts:
     type: public
     is_bootstrap_baker_account: false
     bootstrap_balance: "500000000000000"
+  bakingbadfaucet:
+    # baking bad maintains a telegram faucet bot
+    # tz1KhnTgwoRRALBX6vRHRnydDGSBFsWtcJxc
+    key: edpkuFRauFAdhipQu9s4xmfNJWmtLxPKpoaoG41gYGq5AgUA43Vxqx
+    type: public
+    is_bootstrap_baker_account: false
+    bootstrap_balance: "500000000000000"
   julien:
     # julien.tesson@tezcore.com
     # for stress testing

--- a/idiazabalnet/values.yaml
+++ b/idiazabalnet/values.yaml
@@ -256,6 +256,14 @@ accounts:
     type: public
     is_bootstrap_baker_account: false
     bootstrap_balance: "500000000000000"
+  julien:
+    # julien.tesson@tezcore.com
+    # for stress testing
+    # tz1PicoD6HTZFNkRpN84VFUvdpT7D6xoR2QD
+    key: edpktnArvYkSArFUGiBN4cmDmor9qwyTFCbAKEMbeSdT3z563SdTXm
+    type: public
+    is_bootstrap_baker_account: false
+    bootstrap_balance: "50000000000000"
 
   nomadic00:
     bootstrap_balance: '2000000000000'

--- a/idiazabalnet/values.yaml
+++ b/idiazabalnet/values.yaml
@@ -9,47 +9,47 @@ node_config_network:
 protocols:
   - command: alpha
 
-    #activation:
-    #  protocol_hash: ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK
-    #  protocol_parameters:
-    #    preserved_cycles: 3
-    #    blocks_per_cycle: 2048
-    #    blocks_per_commitment: 64
-    #    blocks_per_stake_snapshot: 512
-    #    blocks_per_voting_period: 40960
-    #    hard_gas_limit_per_operation: '1040000'
-    #    hard_gas_limit_per_block: '5200000'
-    #    proof_of_work_threshold: '-1'
-    #    tokens_per_roll: '8000000000'
-    #    seed_nonce_revelation_tip: '125000'
-    #    baking_reward_fixed_portion: '10000000'
-    #    baking_reward_bonus_per_slot: '4286'
-    #    endorsing_reward_per_slot: '2857'
-    #    hard_storage_limit_per_operation: '60000'
-    #    origination_size: 257
-    #    cost_per_byte: '250'
-    #    quorum_max: 7000
-    #    quorum_min: 2000
-    #    min_proposal_quorum: 500
-    #    liquidity_baking_subsidy: '2500000'
-    #    liquidity_baking_sunset_level: 525600
-    #    liquidity_baking_escape_ema_threshold: 100000
-    #    max_operations_time_to_live: 120
-    #    round_durations:
-    #      - "30"
-    #      - "45"
-    #    consensus_committee_size: 7000
-    #    consensus_threshold: 4667
-    #    minimal_participation_ratio:
-    #      numerator: 2
-    #      denominator: 3
-    #    max_slashing_period: 2
-    #    frozen_deposits_percentage: 10
-    #    double_baking_punishment: "640000000"
-    #    ratio_of_frozen_deposits_slashed_per_double_endorsement:
-    #      numerator: 1
-    #      denominator: 2
-    #    delegate_selection: "random"
+activation:
+  protocol_hash: ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK
+  protocol_parameters:
+    preserved_cycles: 3
+    blocks_per_cycle: 2048
+    blocks_per_commitment: 64
+    blocks_per_stake_snapshot: 512
+    blocks_per_voting_period: 40960
+    hard_gas_limit_per_operation: '1040000'
+    hard_gas_limit_per_block: '5200000'
+    proof_of_work_threshold: '-1'
+    tokens_per_roll: '8000000000'
+    seed_nonce_revelation_tip: '125000'
+    baking_reward_fixed_portion: '10000000'
+    baking_reward_bonus_per_slot: '4286'
+    endorsing_reward_per_slot: '2857'
+    hard_storage_limit_per_operation: '60000'
+    origination_size: 257
+    cost_per_byte: '250'
+    quorum_max: 7000
+    quorum_min: 2000
+    min_proposal_quorum: 500
+    liquidity_baking_subsidy: '2500000'
+    liquidity_baking_sunset_level: 525600
+    liquidity_baking_escape_ema_threshold: 100000
+    max_operations_time_to_live: 120
+    round_durations:
+      - "30"
+      - "45"
+    consensus_committee_size: 7000
+    consensus_threshold: 4667
+    minimal_participation_ratio:
+      numerator: 2
+      denominator: 3
+    max_slashing_period: 2
+    frozen_deposits_percentage: 10
+    double_baking_punishment: "640000000"
+    ratio_of_frozen_deposits_slashed_per_double_endorsement:
+      numerator: 1
+      denominator: 2
+    delegate_selection: "random"
 
 nodes:
   tezos-baking-node:

--- a/index.ts
+++ b/index.ts
@@ -216,7 +216,7 @@ const idiazabalnet_chain = new TezosChain(
     chartRepo: "https://oxheadalpha.github.io/tezos-helm-charts/",
     chartRepoVersion: "5.3.3",
     privateBakingKey: private_oxhead_baking_key,
-    numberOfFaucetAccounts: 0,
+    numberOfFaucetAccounts: 10000,
     faucetSeed: faucetSeed,
     faucetRecaptchaSiteKey: faucetRecaptchaSiteKey,
     faucetRecaptchaSecretKey: faucetRecaptchaSecretKey,


### PR DESCRIPTION
This uncomments the `activation` section of the values.yaml, resulting
of creation of an activation job which activtes the chain. It also sets
the number of faucets back to 10000 so the faucet server will start.

This has to go `up` after the activation date and time in the
values.yaml file. Otherwise, activation will fail.

If activation fails for any reason, it's always possible to delete the
job, then `up --refresh` will create a fresh job that will attempt
activation again.

But activation is irreversible - once a block has been out and
propagated to peers, it's too late. Measure twice, cut once.