### PR TITLE
Use Baking Bad's Telegram bot faucet for Idiazabalnet

### DIFF
--- a/idiazabalnet/README.md
+++ b/idiazabalnet/README.md
@@ -1,6 +1,6 @@
 🔥 If you're here, this means you belong to one of the few lucky people to take part into the testnet using the brand new consensus algorithm [Tenderbake](https://blog.nomadic-labs.com/a-look-ahead-to-tenderbake.html). Congratulations and thanks in advance! This page shows you how to set up your system and actively participate in testing Tenderbake.
 
-⚠️  We are maintaining a [`testnet/idiazabalnet`](https://gitlab.com/nomadic-labs/tezos/-/tree/testnet/idiazabalnet) branch with a snapshot of protocol alpha from 2021-11-06. If any upgrades are needed, they will go to this branch. **Do not use most recent master branch**.
+⚠️  We are maintaining a [`testnet/idiazabalnet`](https://gitlab.com/nomadic-labs/tezos/-/tree/testnet/idiazabalnet) branch with a snapshot of protocol alpha from 2021-11-22. If any upgrades are needed, they will go to this branch. **Do not use most recent master branch**.
 
 ⚠️  There are no released packages or binaries for this testnet. You must build from source or use Docker.
 
@@ -10,8 +10,9 @@
 
 ⚠️  Idiazabalnet does not upgrade and stays on the same protocol from genesis.
 
-⚠️  initially, 67% of the stake will belong to Nomadic Labs bakers, in order to faciliate debugging.
+⚠️  initially, 67% of the stake will belong to Nomadic Labs bakers, in order to facilitate debugging.
 
+⚠️ Our regular faucets created for each testnet does not work Idiazabalnet. The Baking Bad team's Telegram bot faucet should be used instead: https://t.me/tezos_faucet_bot
 ### Report bugs
 
 You are encouraged to run the baker in debug mode:

--- a/index.ts
+++ b/index.ts
@@ -270,10 +270,15 @@ function getTeztnets(chains: TezosChain[]): object {
   const teztnets: { [name: string]: { [name: string]: Object } } = {}
 
   chains.forEach(function (chain) {
+    const chainName = chain.params.getName()
     let faucetUrl
-    if (chain.params.getName() == "granadanet") {
+
+    if (chainName === "granadanet") {
       // legacy faucet
       faucetUrl = "https://faucet.tzalpha.net"
+    } else if (chainName === "idiazabalnet") {
+      // Baking Bad's faucet Telegram bot
+      faucetUrl = "https://t.me/tezos_faucet_bot"
     } else {
       faucetUrl = `https://teztnets.xyz/${chain.params.getName()}-faucet`
     }


### PR DESCRIPTION
Our regular faucet does not work, as commitments were not added to the parameters.json via the chain activation job. This was due a bug: https://github.com/oxheadalpha/tezos-k8s/pull/331