### PR TITLE
Jakartanet: Use bootstrap peers in values.yaml

### DIFF
--- a/jakartanet/values.yaml
+++ b/jakartanet/values.yaml
@@ -308,13 +308,12 @@ nodes:
   # Overwrite default values.yaml rolling-node
   rolling-node: null
 
-    # FIXME uncomment this
-    #bootstrap_peers:
-    #  - jakartanet.smartpy.io
-    #  - jakartanet.kaml.fr
-    #  - jakartanet.boot.ecadinfra.com
-    #  - jakartanet.stakenow.de:9733
-    #  - jakartanet.visualtez.com
+bootstrap_peers:
+  - jakartanet.smartpy.io
+  - jakartanet.kaml.fr
+  - jakartanet.boot.ecadinfra.com
+  - jakartanet.stakenow.de:9733
+  - jakartanet.visualtez.com
 
 full_snapshot_url: null
 rolling_snapshot_url: null


### PR DESCRIPTION
Not sure that this is needed as the peers are specified when creating the network in index.ts. Uncommenting anyways due to the FIXME and just to be sure.