### PR TITLE
Update challenge period for SCORU

### DIFF
--- a/dailynet/values.yaml
+++ b/dailynet/values.yaml
@@ -110,7 +110,7 @@ activation:
     tx_rollup_sunset_level: 3473409
     sc_rollup_enable: true
     sc_rollup_origination_size: 6314
-    sc_rollup_challenge_window_in_blocks: 20160
+    sc_rollup_challenge_window_in_blocks: 40
     sc_rollup_max_available_messages: 1000000
     sc_rollup_stake_amount_in_mutez: 32000000
     sc_rollup_commitment_frequency_in_blocks: 20

--- a/mondaynet/values.yaml
+++ b/mondaynet/values.yaml
@@ -135,7 +135,7 @@ activation:
     tx_rollup_sunset_level: 10000000
     sc_rollup_enable: true
     sc_rollup_origination_size: 6314
-    sc_rollup_challenge_window_in_blocks: 20160
+    sc_rollup_challenge_window_in_blocks: 40
     sc_rollup_max_available_messages: 1000000
 
 nodes:


### PR DESCRIPTION
This MR updates the challenge period for SCORU to make it possible to
test cementing and refutation on the dailynet and the mondaynet.
