### PR TITLE
ghostnet: update ithacanet to jakarta protocol

### DIFF
--- a/ithacanet/values.yaml
+++ b/ithacanet/values.yaml
@@ -8,6 +8,9 @@ node_config_network:
   user_activated_upgrades:
     - level: 8191
       replacement_protocol: Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A
+      # update to jakarta at the end of cycle 186, estimated to be on June 28th at 08:30 UTC
+    - level: 765952
+      replacement_protocol: PtJakart2xVj7pYXJBXrqHgd82rdkLey5ZeeGwDgPp9rhQUbSqY
 
 protocols:
   - command: 012-Psithaca


### PR DESCRIPTION
We are planning to perform the upgrade slightly before mainnet.

Considering that at the moment all top 20 ithacanet bakers are alive and
performing well, we think the timelines are going to be:

| Network     | First Jakarta cycle | Update block | Update time |
| ----------- | ----------- | -- | -- |
| Mainnet      | 498       | 2,490,368 | Jun 28, 2022 17:15 UTC |
| Ghostnet / Ithacanet      | 187       | 765,952 | Jun 28, 2022 08:30 UTC |

Every ithacanet baker will have to change their config to add the
user-activated upgrade, in order to switch to the new protocol. If not,
they will be "stuck".

This is assuming 67% of the network upgrades, which will probably be the
case: Oxhead and Ecad bakers currently control 60% of the network, which
is very close to the required 67%.