### PR TITLE
Ithacanet ghostnet

### DIFF
--- a/TezosChain.ts
+++ b/TezosChain.ts
@@ -414,76 +414,80 @@ export class TezosChain extends pulumi.ComponentResource {
     })
 
     let _cacheFrom: docker.CacheFrom = {}
-    // RPC Ingress
-    const rpcDomain = `rpc.${teztnetsDomain}`
-    const rpcCert = new aws.acm.Certificate(
-      `${rpcDomain}-cert`,
-      {
-        validationMethod: "DNS",
-        domainName: rpcDomain,
-      },
-      { parent: this }
-    )
-    const { certValidation } = createCertValidation(
-      {
-        cert: rpcCert,
-        targetDomain: rpcDomain,
-        hostedZone: this.zone,
-      },
-      { parent: this }
-    )
+    let allNames: string[] = [...params.getAliases(), ...[name]];
 
-    const rpcIngName = `${rpcDomain}-ingress`
-    const rpc_ingress = new k8s.networking.v1beta1.Ingress(
-      rpcIngName,
-      {
-        metadata: {
-          namespace: ns.metadata.name,
-          name: rpcIngName,
-          annotations: {
-            "kubernetes.io/ingress.class": "alb",
-            "alb.ingress.kubernetes.io/scheme": "internet-facing",
-            "alb.ingress.kubernetes.io/healthcheck-path":
-              "/chains/main/chain_id",
-            "alb.ingress.kubernetes.io/healthcheck-port": "8732",
-            "alb.ingress.kubernetes.io/listen-ports":
-              '[{"HTTP": 80}, {"HTTPS":443}]',
-            "ingress.kubernetes.io/force-ssl-redirect": "true",
-            "alb.ingress.kubernetes.io/actions.ssl-redirect":
-              '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}',
-            // Prevent pulumi erroring if ingress doesn't resolve immediately
-            "pulumi.com/skipAwait": "true",
-          },
-          labels: { app: "tezos-node" },
+    allNames.forEach(name => {
+      // RPC Ingress
+      const rpcDomain = `rpc.${name}.teztnets.xyz`
+      const rpcCert = new aws.acm.Certificate(
+        `${rpcDomain}-cert`,
+        {
+          validationMethod: "DNS",
+          domainName: rpcDomain,
         },
-        spec: {
-          rules: [
-            {
-              host: rpcDomain,
-              http: {
-                paths: [
-                  {
-                    path: "/*",
-                    backend: {
-                      serviceName: "ssl-redirect",
-                      servicePort: "use-annotation",
-                    },
-                  },
-                  {
-                    path: "/*",
-                    backend: {
-                      serviceName: "tezos-node-rpc",
-                      servicePort: "rpc",
-                    },
-                  },
-                ],
-              },
+        { parent: this }
+      )
+      const { certValidation } = createCertValidation(
+        {
+          cert: rpcCert,
+          targetDomain: rpcDomain,
+          hostedZone: this.zone,
+        },
+        { parent: this }
+      )
+
+      const rpcIngName = `${rpcDomain}-ingress`
+      const rpc_ingress = new k8s.networking.v1beta1.Ingress(
+        rpcIngName,
+        {
+          metadata: {
+            namespace: ns.metadata.name,
+            name: rpcIngName,
+            annotations: {
+              "kubernetes.io/ingress.class": "alb",
+              "alb.ingress.kubernetes.io/scheme": "internet-facing",
+              "alb.ingress.kubernetes.io/healthcheck-path":
+                "/chains/main/chain_id",
+              "alb.ingress.kubernetes.io/healthcheck-port": "8732",
+              "alb.ingress.kubernetes.io/listen-ports":
+                '[{"HTTP": 80}, {"HTTPS":443}]',
+              "ingress.kubernetes.io/force-ssl-redirect": "true",
+              "alb.ingress.kubernetes.io/actions.ssl-redirect":
+                '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}',
+              // Prevent pulumi erroring if ingress doesn't resolve immediately
+              "pulumi.com/skipAwait": "true",
             },
-          ],
+            labels: { app: "tezos-node" },
+          },
+          spec: {
+            rules: [
+              {
+                host: rpcDomain,
+                http: {
+                  paths: [
+                    {
+                      path: "/*",
+                      backend: {
+                        serviceName: "ssl-redirect",
+                        servicePort: "use-annotation",
+                      },
+                    },
+                    {
+                      path: "/*",
+                      backend: {
+                        serviceName: "tezos-node-rpc",
+                        servicePort: "rpc",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
         },
-      },
-      { provider, parent: this, dependsOn: certValidation }
-    )
+        { provider, parent: this, dependsOn: certValidation }
+      )
+    })
 
     let tezosK8sImages;
     let pulumiTaggedImages;
@@ -555,7 +559,6 @@ export class TezosChain extends pulumi.ComponentResource {
       );
     }
 
-    let allNames: string[] = [...params.getAliases(), ...[name]];
 
     allNames.forEach(name => {
       new k8s.core.v1.Service(

--- a/index.ts
+++ b/index.ts
@@ -185,8 +185,8 @@ const mondaynet_chain = new TezosChain(
 const ghostnet_chain = new TezosChain(
   new TezosChainParametersBuilder({
     yamlFile: "ghostnet/values.yaml",
-    name: "ithacanet",
-    dnsName: "ithacanet",
+    name: "ghostnet",
+    dnsName: "ghostnet",
     category: longCategory,
     humanName: "Ghostnet",
     description: "Ghostnet is the long-running testnet for Tezos",

--- a/index.ts
+++ b/index.ts
@@ -186,6 +186,7 @@ const ghostnet_chain = new TezosChain(
   new TezosChainParametersBuilder({
     yamlFile: "ghostnet/values.yaml",
     name: "ghostnet",
+    aliases: ["ithacanet"],
     dnsName: "ghostnet",
     category: longCategory,
     humanName: "Ghostnet",


### PR DESCRIPTION
rename ithaca namespace to ghostnet. this will cause the node to go down and be recreated from tarball.

Introduce an `aliases` mechanism to keep the old rpc/p2p load balancers alive.