### PR TITLE
Fix AWS S3 public access block

### DIFF
--- a/TezosChain.ts
+++ b/TezosChain.ts
@@ -362,6 +362,13 @@ export class TezosChain extends pulumi.ComponentResource {
 
     if (("activation" in params.helmValues) && params.getContracts()) {
       const activationBucket = new aws.s3.Bucket(`${name}-activation-bucket`);
+      const activationBucketPublicAccessBlock = new aws.s3.BucketPublicAccessBlock(`${name}-activation-bucket-public-access-block`, {
+        bucket: activationBucket.id,
+        blockPublicAcls: false,
+        blockPublicPolicy: false,
+        ignorePublicAcls: false,
+        restrictPublicBuckets: false,
+      });
       const bucketPolicy = new aws.s3.BucketPolicy(`${name}-activation-bucket-policy`, {
         bucket: activationBucket.bucket,
         policy: activationBucket.bucket.apply(publicReadPolicyForBucket)
@@ -375,7 +382,6 @@ export class TezosChain extends pulumi.ComponentResource {
             key: contractFile,
             source: new pulumi.asset.FileAsset(`bootstrap_contracts/${contractFile}`),
             contentType: mime.getType(contractFile),
-            acl: 'public-read'
           });
           params.helmValues["activation"]["bootstrap_contract_urls"].push(pulumi.interpolate`https://${activationBucket.bucketRegionalDomainName}/${contractFile}`);
         })


### PR DESCRIPTION
As of April 2023 AWS is **enabling** public access block on all new S3 buckets.

https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html#:~:text=it%20through%20ACLs.-,Important,-Starting%20in%20April

This prevents the application of public permissions to a bucket policy, among other things.

This fix disables the public access block and removes the acl `public-read` as by default this is not allowed on bucket creation.