### PR TITLE
set up dal_config for dailynet and mondaynet

### DIFF
--- a/dailynet/values.yaml
+++ b/dailynet/values.yaml
@@ -10,6 +10,13 @@ node_config_network:
   genesis:
     block: BMFCHw1mv3A71KpTuGD3MoFnkHk9wvTYjUzuR9QqiUumKGFG6pM
     protocol: Ps9mPmXaRzmzk35gbAYNCAw6UXdE2qoABTHbN2oEEc1qM7CwT9P
+  dal_config:
+    - activated: true
+      use_mock_srs_for_testing:
+        redundancy_factor: 16
+        page_size: 4096
+        slot_size: 1048576
+        number_of_shards: 2048
 
 protocols:
   - command: alpha

--- a/mondaynet/values.yaml
+++ b/mondaynet/values.yaml
@@ -5,6 +5,13 @@ node_config_network:
   user_activated_upgrades:
     - level: 512
       replacement_protocol: ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK
+  dal_config:
+    - activated: true
+      use_mock_srs_for_testing:
+        redundancy_factor: 16
+        page_size: 4096
+        slot_size: 1048576
+        number_of_shards: 2048
 
 activation:
   protocol_hash: PtNairobiyssHuh87hEhfVBGCVrK3WnS8Z2FT4ymB5tAa4r1nQf


### PR DESCRIPTION
In [this](https://gitlab.com/tezos/tezos/-/merge_requests/9228/) MR we moved the DAL config into a new `dal_config` field in the network definition. This was done so that DAL configuration can be shared between nodes in the testnet.

In this PR, we set the `dal_config` to the values we want to use in dailynet and mondaynet.

Do note that this config will not work until https://gitlab.com/tezos/tezos/-/merge_requests/9228/ is merged.