### PR TITLE
Fix remote chart not working + re-configure node groups

### DIFF
--- a/TezosChain.ts
+++ b/TezosChain.ts
@@ -300,7 +300,7 @@ export class TezosChainParametersBuilder implements TezosHelmParameters, TezosIn
     return this;
   }
   public getChartRepo(): string {
-    return this._chartRepo;
+    return this._chartRepo || "https://oxheadalpha.github.io/tezos-helm-charts/"
   }
   public getChartRepoVersion(): string {
     return this._chartRepoVersion;
@@ -647,7 +647,7 @@ export class TezosChain extends pulumi.ComponentResource {
       )
     }
     if (Object.keys(params.helmValues).length != 0) {
-      if (params.getChartRepo() == '') {
+      if (params.getChartPath()) {
         // assume tezos-k8s submodule present; build custom images, and deploy custom chart from path
 
         const chain = new k8s.helm.v2.Chart(

--- a/index.ts
+++ b/index.ts
@@ -161,7 +161,6 @@ const dailynet_chain = new TezosChain(
       "A testnet that restarts every day launched from tezos/tezos master branch and protocol alpha.",
     schedule: "0 0 * * *",
     bootstrapContracts: ["taquito_big_map_contract.json", "taquito_contract.json", "taquito_sapling_contract.json", "taquito_tzip_12_16_contract.json"],
-    // chartRepo: "https://oxheadalpha.github.io/tezos-helm-charts/",
     // chartRepoVersion: "6.18.0",
     chartPath: "dailynet/tezos-k8s",
     privateBakingKey: private_oxhead_baking_key,
@@ -189,7 +188,6 @@ const mondaynet_chain = new TezosChain(
       "mondaynet.ecadinfra.com",
     ],
     bootstrapContracts: ["taquito_big_map_contract.json", "taquito_contract.json", "taquito_sapling_contract.json", "taquito_tzip_12_16_contract.json"],
-    // chartRepo: "https://oxheadalpha.github.io/tezos-helm-charts/",
     // chartRepoVersion: "6.18.0",
     chartPath: "dailynet/tezos-k8s",
     privateBakingKey: private_oxhead_baking_key,
@@ -211,7 +209,6 @@ new TezosChain(
     name: "ghostnet",
     dnsName: "ghostnet",
     humanName: "Ghostnet",
-    chartRepo: "https://oxheadalpha.github.io/tezos-helm-charts/",
     chartRepoVersion: "6.20.2",
   }),
   cluster.provider,
@@ -231,32 +228,25 @@ const nairobinet_chain = new TezosChain(
     category: protocolCategory,
     humanName: "Nairobinet",
     description: "Test Chain for the Nairobi Protocol Proposal",
-    bootstrapPeers: [
-      "nairobinet.boot.ecadinfra.com",
-      "nairobinet.tzboot.net",
-    ],
-    // chartRepo: "https://oxheadalpha.github.io/tezos-helm-charts/",
-    // chartRepoVersion: "6.19.1",
-    chartPath: "nairobinet/tezos-k8s",
+    bootstrapPeers: ["nairobinet.boot.ecadinfra.com", "nairobinet.tzboot.net"],
+    chartRepoVersion: "6.21.0",
     privateBakingKey: private_oxhead_baking_key,
     indexers: [
       {
         name: "TzKT",
-        url: "https://nairobinet.tzkt.io"
+        url: "https://nairobinet.tzkt.io",
       },
       {
-        "name": "TzStats",
-        "url": "https://nairobi.tzstats.com"
-      }
+        name: "TzStats",
+        url: "https://nairobi.tzstats.com",
+      },
     ],
-    rpcUrls: [
-      "https://nairobinet.ecadinfra.com",
-    ],
+    rpcUrls: ["https://nairobinet.ecadinfra.com"],
     activationBucket: activationBucket,
   }),
   cluster.provider,
   repo,
-  teztnetsHostedZone,
+  teztnetsHostedZone
 )
 
 function getNetworks(chains: TezosChain[]): object {

--- a/pulumi/monitoring.ts
+++ b/pulumi/monitoring.ts
@@ -1,15 +1,18 @@
-import * as aws from "@pulumi/aws"
 import * as pulumi from "@pulumi/pulumi"
 import * as k8s from "@pulumi/kubernetes"
 import * as eks from "@pulumi/eks"
 
-const deployMonitoring = (cluster: eks.Cluster, slackWebhook: pulumi.Output<string>) => {
-  const alertTitle = '[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }} for {{ .CommonLabels.job }}'
+const deployMonitoring = (
+  cluster: eks.Cluster,
+  slackWebhook: pulumi.Output<string>
+) => {
+  const alertTitle =
+    '[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }} for {{ .CommonLabels.job }}'
   const alertText = `{{ range .Alerts -}}
   *Alert:* {{ .Annotations.title }}{{ if .Labels.severity }} - {{ .Labels.severity }}{{ end }}
-  
+
   *Description:* {{ .Annotations.description }}
-  
+
   *Details:*
     {{ range .Labels.SortedPairs }} • *{{ .Name }}:* {{ .Value }}
     {{ end }}
@@ -18,118 +21,133 @@ const deployMonitoring = (cluster: eks.Cluster, slackWebhook: pulumi.Output<stri
   const alertmanagerConfig = {
     global: {
       slack_api_url: slackWebhook,
-      resolve_timeout: '5m',
+      resolve_timeout: "5m",
     },
     route: {
-      group_by: ['alertname', 'job', 'service'],
-      group_wait: '30s',
-      group_interval: '5m',
-      repeat_interval: '12h',
-      receiver: 'oxhead_slack',
+      group_by: ["alertname", "job", "service"],
+      group_wait: "30s",
+      group_interval: "5m",
+      repeat_interval: "12h",
+      receiver: "oxhead_slack",
       routes: [
         {
           match: {
-            alertname: 'Watchdog',
+            alertname: "Watchdog",
           },
-          receiver: 'null',
-        }, {
+          receiver: "null",
+        },
+        {
           match: {
-            alertname: 'CPUThrottlingHigh',
+            alertname: "CPUThrottlingHigh",
           },
-          receiver: 'null',
-        }
+          receiver: "null",
+        },
       ],
     },
     receivers: [
       {
-        name: "null"
-      }, {
-        name: 'oxhead_slack',
+        name: "null",
+      },
+      {
+        name: "oxhead_slack",
         slack_configs: [
           {
-            channel: '#infra',
+            channel: "#infra",
             send_resolved: true,
-            icon_url: 'https://avatars3.githubusercontent.com/u/3380462',
+            icon_url: "https://avatars3.githubusercontent.com/u/3380462",
             title: alertTitle,
             text: alertText,
-          }
+          },
         ],
-      }
-    ]
+      },
+    ],
   }
 
-  const monitorNamespace = new k8s.core.v1.Namespace("monitoring", {
-    metadata: {
-      name: "monitoring",
-    }
-  }, {
-    provider: cluster.provider,
-  });
-
-  const monitorStack = new k8s.helm.v3.Chart("monitoring", {
-    chart: "kube-prometheus-stack",
-    fetchOpts: {
-      repo: "https://prometheus-community.github.io/helm-charts",
+  const monitorNamespace = new k8s.core.v1.Namespace(
+    "monitoring",
+    {
+      metadata: { name: "monitoring" },
     },
-    version: "19.0.1",
-    values: {
-      kubeApiServer: {
-        enabled: false
+    {
+      provider: cluster.provider,
+      parent: cluster,
+    }
+  )
+
+  const monitorStack = new k8s.helm.v3.Chart(
+    "monitoring",
+    {
+      chart: "kube-prometheus-stack",
+      fetchOpts: {
+        repo: "https://prometheus-community.github.io/helm-charts",
       },
-      kubelet: {
-        enabled: true
-      },
-      kubeControllerManager: {
-        enabled: false
-      },
-      coreDns: {
-        enabled: true
-      },
-      kubeDns: {
-        enabled: false
-      },
-      kubeEtcd: {
-        enabled: false
-      },
-      kubeScheduler: {
-        enabled: false
-      },
-      kubeProxy: {
-        enabled: false
-      },
-      nodeExporter: {
-        hostNetwork: false,
-      },
-      grafana: {
-        adminPassword: 'grafana',
-      },
-      alertmanager: {
-        config: alertmanagerConfig,
-      },
-      prometheus: {
-        prometheusSpec: {
-          podMonitorNamespaceSelector: {
-            any: true,
-          },
-          serviceMonitorNamespaceSelector: {
-            any: true,
+      version: "19.0.1",
+      namespace: monitorNamespace.metadata.name,
+      values: {
+        kubeApiServer: {
+          enabled: false,
+        },
+        kubelet: {
+          enabled: true,
+        },
+        kubeControllerManager: {
+          enabled: false,
+        },
+        coreDns: {
+          enabled: true,
+        },
+        kubeDns: {
+          enabled: false,
+        },
+        kubeEtcd: {
+          enabled: false,
+        },
+        kubeScheduler: {
+          enabled: false,
+        },
+        kubeProxy: {
+          enabled: false,
+        },
+        nodeExporter: {
+          hostNetwork: false,
+        },
+        grafana: {
+          adminPassword: "grafana",
+        },
+        alertmanager: {
+          config: alertmanagerConfig,
+        },
+        prometheus: {
+          prometheusSpec: {
+            podMonitorNamespaceSelector: {
+              any: true,
+            },
+            serviceMonitorNamespaceSelector: {
+              any: true,
+            },
           },
         },
       },
     },
-    namespace: monitorNamespace.metadata.name
-  }, {
-    provider: cluster.provider,
-    dependsOn: [monitorNamespace],
-  });
-  const tezosPromStack = new k8s.helm.v3.Chart("tezos-prom", {
-    chart: "tezos-prometheus-stack",
-    path: "charts",
-    namespace: monitorNamespace.metadata.name
-  }, {
-    provider: cluster.provider,
-    dependsOn: [monitorNamespace],
-  });
+    {
+      provider: cluster.provider,
+      dependsOn: [monitorNamespace],
+      parent: monitorNamespace,
+    }
+  )
+  const tezosPromStack = new k8s.helm.v3.Chart(
+    "tezos-prom",
+    {
+      chart: "tezos-prometheus-stack",
+      path: "charts",
+      namespace: monitorNamespace.metadata.name,
+    },
+    {
+      provider: cluster.provider,
+      dependsOn: [monitorNamespace],
+      parent: monitorNamespace,
+    }
+  )
 }
 
 export default deployMonitoring


### PR DESCRIPTION
- when setting a chart version to install a remote chart, a local submodule chart would still try to be installed
- removed old node group not being used
- Use 'parent' to organize the monitoring resources properly