### PR TITLE
Evm deposit dailynet

### DIFF
--- a/bootstrap_contracts/evm_bridge.json
+++ b/bootstrap_contracts/evm_bridge.json
@@ -1,0 +1,597 @@
+{
+  "amount": "0",
+  "script": {
+    "code": [
+      {
+        "prim": "parameter",
+        "args": [
+          {
+            "prim": "or",
+            "args": [
+              {
+                "prim": "or",
+                "args": [
+                  {
+                    "prim": "pair",
+                    "args": [
+                      {
+                        "prim": "pair",
+                        "args": [
+                          {
+                            "prim": "nat",
+                            "annots": [
+                              "%amount"
+                            ]
+                          },
+                          {
+                            "prim": "bytes",
+                            "annots": [
+                              "%evm_address"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "prim": "nat",
+                        "annots": [
+                          "%max_gas_price"
+                        ]
+                      }
+                    ],
+                    "annots": [
+                      "%deposit"
+                    ]
+                  },
+                  {
+                    "prim": "address",
+                    "annots": [
+                      "%set"
+                    ]
+                  }
+                ]
+              },
+              {
+                "prim": "pair",
+                "args": [
+                  {
+                    "prim": "address"
+                  },
+                  {
+                    "prim": "nat"
+                  }
+                ],
+                "annots": [
+                  "%withdraw"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "prim": "storage",
+        "args": [
+          {
+            "prim": "pair",
+            "args": [
+              {
+                "prim": "pair",
+                "args": [
+                  {
+                    "prim": "address",
+                    "annots": [
+                      "%admin"
+                    ]
+                  },
+                  {
+                    "prim": "address",
+                    "annots": [
+                      "%ctez_contract"
+                    ]
+                  }
+                ]
+              },
+              {
+                "prim": "option",
+                "args": [
+                  {
+                    "prim": "address"
+                  }
+                ],
+                "annots": [
+                  "%rollup"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "prim": "code",
+        "args": [
+          [
+            {
+              "prim": "UNPAIR"
+            },
+            {
+              "prim": "IF_LEFT",
+              "args": [
+                [
+                  {
+                    "prim": "IF_LEFT",
+                    "args": [
+                      [
+                        {
+                          "prim": "UNPAIR"
+                        },
+                        {
+                          "prim": "UNPAIR"
+                        },
+                        {
+                          "prim": "DUP",
+                          "args": [
+                            {
+                              "int": "4"
+                            }
+                          ]
+                        },
+                        {
+                          "prim": "SENDER"
+                        },
+                        {
+                          "prim": "SELF_ADDRESS"
+                        },
+                        {
+                          "prim": "DUP",
+                          "args": [
+                            {
+                              "int": "7"
+                            }
+                          ]
+                        },
+                        {
+                          "prim": "CAR"
+                        },
+                        {
+                          "prim": "CDR"
+                        },
+                        {
+                          "prim": "CONTRACT",
+                          "args": [
+                            {
+                              "prim": "pair",
+                              "args": [
+                                {
+                                  "prim": "address",
+                                  "annots": [
+                                    "%from"
+                                  ]
+                                },
+                                {
+                                  "prim": "address",
+                                  "annots": [
+                                    "%to"
+                                  ]
+                                },
+                                {
+                                  "prim": "nat",
+                                  "annots": [
+                                    "%value"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "annots": [
+                            "%transfer"
+                          ]
+                        },
+                        {
+                          "prim": "IF_NONE",
+                          "args": [
+                            [
+                              {
+                                "prim": "PUSH",
+                                "args": [
+                                  {
+                                    "prim": "string"
+                                  },
+                                  {
+                                    "string": "Failed to find the entrypoint %transfer"
+                                  }
+                                ]
+                              },
+                              {
+                                "prim": "FAILWITH"
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "prim": "DIG",
+                          "args": [
+                            {
+                              "int": "7"
+                            }
+                          ]
+                        },
+                        {
+                          "prim": "CDR"
+                        },
+                        {
+                          "prim": "IF_NONE",
+                          "args": [
+                            [
+                              {
+                                "prim": "PUSH",
+                                "args": [
+                                  {
+                                    "prim": "string"
+                                  },
+                                  {
+                                    "string": "The EVM rollup was not set"
+                                  }
+                                ]
+                              },
+                              {
+                                "prim": "FAILWITH"
+                              }
+                            ],
+                            [
+                              {
+                                "prim": "CONTRACT",
+                                "args": [
+                                  {
+                                    "prim": "pair",
+                                    "args": [
+                                      {
+                                        "prim": "pair",
+                                        "args": [
+                                          {
+                                            "prim": "bytes"
+                                          },
+                                          {
+                                            "prim": "ticket",
+                                            "args": [
+                                              {
+                                                "prim": "unit"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "prim": "nat"
+                                      },
+                                      {
+                                        "prim": "bytes"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "prim": "IF_NONE",
+                                "args": [
+                                  [
+                                    {
+                                      "prim": "PUSH",
+                                      "args": [
+                                        {
+                                          "prim": "string"
+                                        },
+                                        {
+                                          "string": "option is None"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "prim": "FAILWITH"
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ]
+                          ]
+                        },
+                        {
+                          "prim": "SWAP"
+                        },
+                        {
+                          "prim": "PUSH",
+                          "args": [
+                            {
+                              "prim": "mutez"
+                            },
+                            {
+                              "int": "0"
+                            }
+                          ]
+                        },
+                        {
+                          "prim": "DUP",
+                          "args": [
+                            {
+                              "int": "7"
+                            }
+                          ]
+                        },
+                        {
+                          "prim": "DIG",
+                          "args": [
+                            {
+                              "int": "4"
+                            }
+                          ]
+                        },
+                        {
+                          "prim": "DIG",
+                          "args": [
+                            {
+                              "int": "5"
+                            }
+                          ]
+                        },
+                        {
+                          "prim": "PAIR",
+                          "args": [
+                            {
+                              "int": "3"
+                            }
+                          ]
+                        },
+                        {
+                          "prim": "TRANSFER_TOKENS"
+                        },
+                        {
+                          "prim": "DIG",
+                          "args": [
+                            {
+                              "int": "3"
+                            }
+                          ]
+                        },
+                        {
+                          "prim": "UNIT"
+                        },
+                        {
+                          "prim": "TICKET"
+                        },
+                        {
+                          "prim": "IF_NONE",
+                          "args": [
+                            [
+                              {
+                                "prim": "PUSH",
+                                "args": [
+                                  {
+                                    "prim": "string"
+                                  },
+                                  {
+                                    "string": "Failed to create the ticket"
+                                  }
+                                ]
+                              },
+                              {
+                                "prim": "FAILWITH"
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "prim": "DIG",
+                          "args": [
+                            {
+                              "int": "2"
+                            }
+                          ]
+                        },
+                        {
+                          "prim": "PUSH",
+                          "args": [
+                            {
+                              "prim": "mutez"
+                            },
+                            {
+                              "int": "0"
+                            }
+                          ]
+                        },
+                        {
+                          "prim": "PUSH",
+                          "args": [
+                            {
+                              "prim": "bytes"
+                            },
+                            {
+                              "bytes": ""
+                            }
+                          ]
+                        },
+                        {
+                          "prim": "DIG",
+                          "args": [
+                            {
+                              "int": "7"
+                            }
+                          ]
+                        },
+                        {
+                          "prim": "PAIR"
+                        },
+                        {
+                          "prim": "DIG",
+                          "args": [
+                            {
+                              "int": "3"
+                            }
+                          ]
+                        },
+                        {
+                          "prim": "DIG",
+                          "args": [
+                            {
+                              "int": "6"
+                            }
+                          ]
+                        },
+                        {
+                          "prim": "PAIR"
+                        },
+                        {
+                          "prim": "PAIR"
+                        },
+                        {
+                          "prim": "TRANSFER_TOKENS"
+                        },
+                        {
+                          "prim": "NIL",
+                          "args": [
+                            {
+                              "prim": "operation"
+                            }
+                          ]
+                        },
+                        {
+                          "prim": "SWAP"
+                        },
+                        {
+                          "prim": "CONS"
+                        },
+                        {
+                          "prim": "SWAP"
+                        },
+                        {
+                          "prim": "CONS"
+                        }
+                      ],
+                      [
+                        {
+                          "prim": "DUP",
+                          "args": [
+                            {
+                              "int": "2"
+                            }
+                          ]
+                        },
+                        {
+                          "prim": "CAR"
+                        },
+                        {
+                          "prim": "CAR"
+                        },
+                        {
+                          "prim": "SENDER"
+                        },
+                        {
+                          "prim": "COMPARE"
+                        },
+                        {
+                          "prim": "NEQ"
+                        },
+                        {
+                          "prim": "IF",
+                          "args": [
+                            [
+                              {
+                                "prim": "DROP",
+                                "args": [
+                                  {
+                                    "int": "2"
+                                  }
+                                ]
+                              },
+                              {
+                                "prim": "PUSH",
+                                "args": [
+                                  {
+                                    "prim": "string"
+                                  },
+                                  {
+                                    "string": "Unauthorized set entrypoint"
+                                  }
+                                ]
+                              },
+                              {
+                                "prim": "FAILWITH"
+                              }
+                            ],
+                            [
+                              {
+                                "prim": "SOME"
+                              },
+                              {
+                                "prim": "UPDATE",
+                                "args": [
+                                  {
+                                    "int": "2"
+                                  }
+                                ]
+                              }
+                            ]
+                          ]
+                        },
+                        {
+                          "prim": "NIL",
+                          "args": [
+                            {
+                              "prim": "operation"
+                            }
+                          ]
+                        }
+                      ]
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "prim": "DROP"
+                  },
+                  {
+                    "prim": "NIL",
+                    "args": [
+                      {
+                        "prim": "operation"
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "prim": "PAIR"
+            }
+          ]
+        ]
+      }
+    ],
+    "storage": {
+      "prim": "Pair",
+      "args": [
+        {
+          "prim": "Pair",
+          "args": [
+            {
+              "string": "tz1R4EjaQqeBhBP2dztahpkzHTZ61PSssqkh"
+            },
+            {
+              "string": "KT1FHqsvc7vRS3u54L66DdMX4gb6QKqxJ1JW"
+            }
+          ]
+        },
+        {
+          "prim": "Some",
+          "args": [
+            {
+              "string": "sr1RYurGZtN8KNSpkMcCt9CgWeUaNkzsAfXf"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "hash": "KT1QwBaLj5TRaGU3qkU4ZKKQ5mvNvyyzGBFv"
+}

--- a/bootstrap_contracts/evm_fa12_contract.json
+++ b/bootstrap_contracts/evm_fa12_contract.json
@@ -1,0 +1,99 @@
+{
+  "amount": "0",
+  "script": {
+    "code": [
+      {
+        "prim": "parameter",
+        "args": [
+          {
+            "prim": "or",
+            "args": [
+              {
+                "prim": "pair",
+                "args": [
+                  {
+                    "prim": "address"
+                  },
+                  {
+                    "prim": "nat"
+                  }
+                ],
+                "annots": [
+                  "%approve"
+                ]
+              },
+              {
+                "prim": "pair",
+                "args": [
+                  {
+                    "prim": "address"
+                  },
+                  {
+                    "prim": "address"
+                  },
+                  {
+                    "prim": "nat"
+                  }
+                ],
+                "annots": [
+                  "%transfer"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "prim": "storage",
+        "args": [
+          {
+            "prim": "unit"
+          }
+        ]
+      },
+      {
+        "prim": "code",
+        "args": [
+          [
+            {
+              "prim": "CAR"
+            },
+            {
+              "prim": "IF_LEFT",
+              "args": [
+                [
+                  {
+                    "prim": "DROP"
+                  }
+                ],
+                [
+                  {
+                    "prim": "DROP"
+                  }
+                ]
+              ]
+            },
+            {
+              "prim": "UNIT"
+            },
+            {
+              "prim": "NIL",
+              "args": [
+                {
+                  "prim": "operation"
+                }
+              ]
+            },
+            {
+              "prim": "PAIR"
+            }
+          ]
+        ]
+      }
+    ],
+    "storage": {
+      "prim": "Unit"
+    }
+  },
+  "hash": "KT1FHqsvc7vRS3u54L66DdMX4gb6QKqxJ1JW"
+}

--- a/dailynet/values.yaml
+++ b/dailynet/values.yaml
@@ -126,7 +126,18 @@ activation:
       pvm_kind: "wasm_2_0_0"
       kernel: "fromfile#/usr/local/share/tezos/evm_kernel/evm_installer.wasm"
       parameters_ty:
-        prim: unit
+        prim: pair
+        args:
+        - prim: pair
+          args:
+          - prim: bytes
+          - prim: ticket
+            args:
+            - prim: unit
+        - prim: pair
+          args:
+          - prim: nat
+          - prim: bytes
 nodes:
   tezos-baking-node:
     instances:

--- a/index.ts
+++ b/index.ts
@@ -151,7 +151,7 @@ const dailynet_chain = new TezosChain(
     description:
       "A testnet that restarts every day launched from tezos/tezos master branch and protocol alpha.",
     schedule: "0 0 * * *",
-    bootstrapContracts: ["taquito_big_map_contract.json", "taquito_contract.json", "taquito_sapling_contract.json", "taquito_tzip_12_16_contract.json"],
+    bootstrapContracts: ["taquito_big_map_contract.json", "taquito_contract.json", "taquito_sapling_contract.json", "taquito_tzip_12_16_contract.json", "evm_bridge.json", "evm_fa12_contract.json"],
     // chartRepoVersion: "6.18.0",
     chartPath: "dailynet/tezos-k8s",
     privateBakingKey: private_oxhead_baking_key,


### PR DESCRIPTION
Mirror merge request of https://gitlab.com/tezos/tezos/-/merge_requests/9843.

This allows to have deposit working on dailynet, it's the same mechanism as for ghostnet. It needs to:

1. Update the smart rollup type, to `pair (pair bytes (ticket unit)) (pair nat bytes)`
2. On ghostnet, we use a ctez contract deployed by Marigold for the tokens. On dailynet, I added a dumb contract that respects the FA1.2 type of %approve and %transfer, making all transfers free.
3. Finally the EVM bridge that uses the contract from (2.) to deposit tokens.

The documentation on how to use is still lacking, but this will allow to have unlimited funds on the EVM rollup for dailynet easily.

I have no idea how I can test this merge request, it impacts the protocol's parameters so a bad encoding could make the dailynet deployment fail. The test added in https://gitlab.com/tezos/tezos/-/merge_requests/9843 deploys a new chain with the same bootstrap accounts and smart rollups, and perform a deposit.