### PR TITLE
Fix awaiter for DAL loadbalancers

### DIFF
--- a/TezosChain.ts
+++ b/TezosChain.ts
@@ -736,7 +736,11 @@ export class TezosChain extends pulumi.ComponentResource {
         { provider: this.provider }
       )
 
-      if (name.includes("dailynet") || name.includes("mondaynet")) {
+      if (
+        name.includes("dailynet") ||
+        name.includes("mondaynet") ||
+        name.includes("weeklynet")
+      ) {
         if (!process.env.KUBECONFIG) {
           throw new Error(
             "KUBECONFIG env var is required when deploying DAL nodes."

--- a/index.ts
+++ b/index.ts
@@ -84,6 +84,7 @@ const dailynet_chain = new TezosChain(
     privateBakingKey: private_oxhead_baking_key,
     activationBucket: activationBucket,
   }),
+  kubeconfig,
   provider
 )
 
@@ -114,6 +115,7 @@ const mondaynet_chain = new TezosChain(
     privateBakingKey: private_oxhead_baking_key,
     activationBucket: activationBucket,
   }),
+  kubeconfig,
   provider
 )
 
@@ -144,6 +146,7 @@ const weeklynet_chain = new TezosChain(
     privateBakingKey: private_oxhead_baking_key,
     activationBucket: activationBucket,
   }),
+  kubeconfig,
   provider
 )
 
@@ -160,6 +163,7 @@ new TezosChain(
     humanName: "Ghostnet",
     chartRepoVersion: "6.23.2",
   }),
+  null,
   provider
 )
 
@@ -191,6 +195,7 @@ const nairobinet_chain = new TezosChain(
     rpcUrls: ["https://nairobinet.ecadinfra.com"],
     activationBucket: activationBucket,
   }),
+  null,
   provider
 )
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@oxheadalpha/tezos-pulumi": "1.0.1",
-        "@pulumi/command": "^0.7.2",
+        "@pulumi/command": "^0.9.2",
         "@pulumi/digitalocean": "^4.22.0",
         "@pulumi/pulumi": "^3.69.0",
         "@pulumi/random": "^4.13.2",
@@ -409,9 +409,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "node_modules/@pulumi/command": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@pulumi/command/-/command-0.7.2.tgz",
-      "integrity": "sha512-R/eAIXIywSkn2cHIaNqs0EXcXduNeDuS+wom6oadB5KEP+6elgJbo4WMDP+OuDYGkkxEWIKjk0bPPO7570aXFQ==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@pulumi/command/-/command-0.9.2.tgz",
+      "integrity": "sha512-9RaGDiy8jFCiaarj4EOrMW/fVCM/AgBigzwM6CKzlR49x8UFiRDmKrXfEVHb8r2P9IpC4IaAZf5VbNNAHwN/rA==",
       "hasInstallScript": true,
       "dependencies": {
         "@pulumi/pulumi": "^3.0.0"
@@ -2627,9 +2627,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@pulumi/command": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@pulumi/command/-/command-0.7.2.tgz",
-      "integrity": "sha512-R/eAIXIywSkn2cHIaNqs0EXcXduNeDuS+wom6oadB5KEP+6elgJbo4WMDP+OuDYGkkxEWIKjk0bPPO7570aXFQ==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@pulumi/command/-/command-0.9.2.tgz",
+      "integrity": "sha512-9RaGDiy8jFCiaarj4EOrMW/fVCM/AgBigzwM6CKzlR49x8UFiRDmKrXfEVHb8r2P9IpC4IaAZf5VbNNAHwN/rA==",
       "requires": {
         "@pulumi/pulumi": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@oxheadalpha/tezos-pulumi": "1.0.1",
-    "@pulumi/command": "^0.7.2",
+    "@pulumi/command": "^0.9.2",
     "@pulumi/digitalocean": "^4.22.0",
     "@pulumi/pulumi": "^3.69.0",
     "@pulumi/random": "^4.13.2",


### PR DESCRIPTION
- auto-formatting
- properly waits for DAL svc loadbalancer's to be provisioned, and passes their ip's as pulumi Outputs to the tezos-k8s chart.

There are no pulumi out-of-the-box solutions for solving the awaiting problem. 
`OutputInstance` [`get()`](https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance-get) methods for example, do not work during preview/updates. Pulumi Resource level `get()` methods don't work as they are meant for importing existing cloud resources into Pulumi's domain.